### PR TITLE
Improvements for web-server option

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Setup root directory
+ROOT="/dev_joomla"
+
 # Check the number of arguments provided
 if [ $# -eq 0 ]; then
   # No input provided, run the local script

--- a/web-server/docker-compose.yml
+++ b/web-server/docker-compose.yml
@@ -2,97 +2,25 @@ version: '3.1'
 
 services:
 
-  # mysql:
-  #   image: mysql:8.0 # Joomla 5 needs >= 8.0.13, actual 8.1.0
-  #   restart: unless-stopped
-  #   command: --default-authentication-plugin=mysql_native_password --sql_mode=""
-  #   environment:
-  #     MYSQL_ROOT_PASSWORD: example12345678
-  #   volumes:
-  #     - ./joomla-backup:/docker-entrypoint-initdb.d
-  #   networks:
-  #     - joomla-network
-
-  # mysqladmin:
-  #   container_name: test_joomla_mysqladmin_web
-  #   image: phpmyadmin/phpmyadmin
-  #   environment:
-  #     PMA_HOST: mysql
-  #   ports:
-  #     - "2001:80"
-  #   restart: unless-stopped
-  #   depends_on:
-  #     - mysql
-  #   networks:
-  #     - joomla-network
-
-  joomla-test:
-    container_name: test_joomla_web
-    image: joomla:5.0 # actual 5.0.0
-    restart: unless-stopped
-    ports:
-      - 2005:80
-    environment:
-      JOOMLA_SITE_NAME: "Joomla Test Site"
-      JOOMLA_ADMIN_USER: admin
-      JOOMLA_ADMIN_USERNAME: admin
-      JOOMLA_ADMIN_PASSOWRD: admin12345678
-      JOOMLA_ADMIN_EMAIL: admin@example.com
-      JOOMLA_DB_HOST: mysql
-      JOOMLA_DB_USER: root
-      JOOMLA_DB_PASSWORD: example12345678
-      # JOOMLA_DB_NAME: joomla
-      JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK: 1
-    volumes:
-      - .:/dev_joomla
-      - joomla-data:/var/www/html
-      - joomla-backup:/var/www/html/backups
-    depends_on:
-      # - mysql
-      - ftpserver
-    networks:
-      - joomla-network
-
   cypress:
     container_name: test_joomla_cypress_web
     image: cypress/included:12.8.1 # actual 13. + Chrome 116. + Edge 116. + Firefox 117.
     restart: "no"
-    entrypoint: /dev_joomla/scripts/exec-cypress.sh
+    entrypoint: ${ROOT}/scripts/exec-cypress.sh
     ports:
       - 2080:80
-    depends_on:
-      - joomla-test
     environment:
-      # CYPRESS_BASE_URL: ''
+      CYPRESS_BASE_URL: ${DOMAIN}
       DISPLAY:
+      JOOMLA_USERNAME: ${USERNAME}
+      JOOMLA_PASSWORD: ${PASSWORD}
+      ROOT: ${ROOT}
     volumes:
-      - .:/dev_joomla
-      - joomla-data:/joomla-data
+      - .:${ROOT}
       - joomla-backup:/var/www/html/backups
       - ~/.Xauthority:/root/.Xauthority:rw
       - /tmp/.X11-unix:/tmp/.X11-unix
     working_dir: /cypress-test/tests
-    networks:
-      - joomla-network
 
-  ftpserver:
-    image: stilliard/pure-ftpd
-    environment:
-      PUBLICHOST: localhost
-      FTP_USER_NAME: ftp
-      FTP_USER_PASS: ftp
-      FTP_USER_HOME: /home/ftp
-    ports:
-      - 21:21
-      - 30000-30009:30000-30009
-    volumes:
-      - joomla-data:/home/ftp
-      - joomla-backup:/home/ftp/backups
-    networks:
-      - joomla-network
-
-networks:
-  joomla-network:
 volumes:
-  joomla-data:
   joomla-backup:

--- a/web-server/scripts/config-setup.sh
+++ b/web-server/scripts/config-setup.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Read database credentials from configuration.php
-# CONFIG_FILE="..\configuration.php"
-CONFIG_FILE="/dev_joomla/joomla-backup/configuration.php"
+CONFIG_FILE="${ROOT}/joomla-backup/configuration.php"
 
 while  ! [ -f "$CONFIG_FILE" ]; do
 	echo "$(date) - Waiting for Joomla configuration file - ${CONFIG_FILE}"
@@ -10,11 +9,6 @@ while  ! [ -f "$CONFIG_FILE" ]; do
 done
 
 ls -l "$CONFIG_FILE"
-
-# if ![ -f CONFIG_FILE ]; then
-# 	echo "No configuration file for Joomla found"
-# 	exit 1
-# fi
 
 DB_SITENAME_LINE=$(grep -oPi 'public \$sitename = ([^;]+);' $CONFIG_FILE | cut --complement -c 1-20)
 DB_EMAIL_LINE=$(grep -oPi 'public \$mailfrom = ([^;]+);' $CONFIG_FILE | cut --complement -c 1-20)
@@ -37,14 +31,17 @@ db_prefix=${DB_PREFIX_LINE:0:-2}
 dummy_config="$(dirname $0)/cypress.config.dist.js"
 
 # Path to your real config file
-# real_config="${PWD}\cypress.config.js"
-real_config="$(dirname $0)/../tests/cypress.config.js"
+real_config="${ROOT}/tests/cypress.config.js"
 
 # Copy the updated dummy config to the real config file
-# cp $dummy_config $real_config
+cp $dummy_config $real_config
 
 # Replace lines in the real config file with data from configuration.php
 sed -i "s/sitename_replace/$db_sitename/g; s/email_replace/$db_email/g; s/db_host_replace/$db_host/g; s/db_name_replace/$db_name/g; s/db_password_replace/$db_password/g; s/db_user_replace/$db_user/g; s/db_prefix_replace/$db_prefix/g;" $real_config
 
+# Update Cypress configuration file with the provided values
+sed -i "s|url_replace|${CYPRESS_BASE_URL}|g; s/username_replace/${JOOMLA_USERNAME}/g; s/password_replace/${JOOMLA_PASSWORD}/g" $real_config
+
+echo "Username and password updated in cypress.config.js"
 
 echo "Configuration updated successfully!"

--- a/web-server/scripts/cypress.config.dist.js
+++ b/web-server/scripts/cypress.config.dist.js
@@ -33,10 +33,10 @@ module.exports = defineConfig({
     password: "password_replace",
     // automatically created from configuration.php
     email: 'email_replace',
-    db_host: 'mysql',
+    db_host: 'db_host_replace',
     db_name: 'db_name_replace',
-    db_user: 'root',
-    db_password: 'example12345678',
+    db_user: 'db_user_replace',
+    db_password: 'db_password_replace',
     db_prefix: 'db_prefix_replace',
     cmsPath: '../../var/www/html',
   },

--- a/web-server/scripts/exec-cypress.sh
+++ b/web-server/scripts/exec-cypress.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 echo "Installing the assets (takes a while!)"
-rm -rf "/dev_joomla/node_modules"
-cd "/dev_joomla"
+rm -rf "${ROOT}/node_modules"
+cd "${ROOT}"
 npm update
 
 echo "Start creating cypress.config.js from Joomla configuration.php"
-source  /dev_joomla/scripts/config-setup.sh
+source  ${ROOT}/scripts/config-setup.sh
 
 echo "Start Cypress"
-cypress open --project /dev_joomla/tests --e2e
+cypress open --project ${ROOT}/tests --e2e
 
 exit 1

--- a/web-server/web.sh
+++ b/web-server/web.sh
@@ -15,26 +15,8 @@ read -p "Enter your site username: " username
 # Prompt user for password (-s for privacy)
 read -p "Enter your site password: " password
 
-# Update Cypress configuration file with the provided values
-sed -i "s|url_replace|$domain|g; s/username_replace/$username/g; s/password_replace/$password/g" $real_config
-
-echo "Username and password updated in cypress.config.js"
-
 echo "Cleaning up the old containers"
 docker compose down --volumes
 
-# if [ ! -d "./www" ]; then
-	# echo "Creating Joomla folder"
-	# mkdir -p "./www"
-# fi
-
-# echo "permissions to write in Joomla folder"
-# chmod 777 ./www
-# echo "Remove Joomla folder"
-# rm -rf "./www/*"
-
-# echo "Start creating cypress.config.js from Joomla configuration.php"
-# source  /dev_joomla/scripts/config-setup.sh
-
 echo "Creating fresh containers and start"
-docker compose up --force-recreate
+ROOT=$ROOT USERNAME=$username PASSWORD=$password DOMAIN=$domain docker compose -f $(dirname $0)/docker-compose.yml up --force-recreate


### PR DESCRIPTION
- setup a variable for the target path of the docker volume '/dev_joomla' to inject the needed files into container
- remove unused containers from docker-compose.yml
- move the update for the prompted values for cypress.config.js in config-setup.sh to have all in one place
- make the scripts executable

**To be noted and to consider**
For the live site scenario many tests have to be rewritten - they need a direct db connection.
Reason for this is that the reset of the seeded data is written directly in the cypress tests and will fail always.
These tests can also run only once cause the data is not reset in db.
There is a missing step to set the db-host in cypress config to point to the external db and not all providers allow access outside of localhost to the db.